### PR TITLE
Add description property to schema

### DIFF
--- a/resources/property-listing.schema.json
+++ b/resources/property-listing.schema.json
@@ -33,6 +33,13 @@
       "description": "How many bedrooms the listing has"
     },
     {
+      "name": "description",
+      "label": "Description",
+      "type": "string",
+      "fieldType": "textarea",
+      "description": "A full description of the property listing"
+    },
+    {
       "name": "dynamic_page_title",
       "label": "Dynamic Page Title",
       "type": "string",


### PR DESCRIPTION
## Details

I've added a description property to the Property Listing schema, which will allow us to display the real estate property's description in the `property-details` module. 

## Who to Notify 

@drewjenkins @gcorne @anthmatic @williamspiro @miketalley