### PR TITLE
Ignore scripts on auto deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
         node-version: 10.x
     - name: Install NPM deps
       run: |
-          npm install
+          npm install --ignore-scripts
     - name: Generate hubspot.config.yml and deploy
       env:
         HUBSPOT_PORTAL_ID: ${{ secrets.HubSpotPortalId }}


### PR DESCRIPTION
The `install` script is not needed for the GH action and is currently causing the action to fail.