### PR TITLE
Removing references of Avenir font

### DIFF
--- a/hub-homes/css/elements/_typography.css
+++ b/hub-homes/css/elements/_typography.css
@@ -4,7 +4,7 @@ html {
 
 body {
   color: #000000;
-  font-family: "Avenir Next Demi Bold", sans-serif;
+  font-family: sans-serif;
   line-height: 1.5;
   word-break: break-word;
 }
@@ -55,7 +55,7 @@ h4,
 h5,
 h6 {
   color: #000000;
-  font-family: "Avenir Next Demi Bold", sans-serif;
+  font-family: sans-serif;
   margin: 0 0 1.5rem;
   line-height: 1.25;
 }

--- a/hub-homes/css/modules/_modules.css
+++ b/hub-homes/css/modules/_modules.css
@@ -52,7 +52,6 @@
 @media (min-width: 1209px) {
   .listing {
     display: flex;
-    font-family: "Avenir Next Demi Bold", Avenir, Times;
     margin: 0 auto;
     width: 80%;
   }


### PR DESCRIPTION
Removing references of Avenir font. Instead of using that I'm just pointing to the fallback font of sans-serif. I removed the font reference in the CSS for `.listing` because it looked like it would be using the same thing as the base font and therefore would be duplicated. I tested my edits using the dev tools in browser and things still look presentable

<img width="1306" alt="Screenshot 2023-03-06 at 4 46 53 PM" src="https://user-images.githubusercontent.com/22665237/223241587-30957c7e-c4dc-4029-89b9-d89521f361c4.png">
