### PR TITLE
Updating favicon to point to brand settings

### DIFF
--- a/hub-homes/templates/layouts/base.html
+++ b/hub-homes/templates/layouts/base.html
@@ -7,8 +7,8 @@
   <head>
     <meta charset="utf-8">
     <title>{{ page_meta.html_title }}</title>
-    {% if site_settings.favicon_src %}
-      <link rel="shortcut icon" href="{{ site_settings.favicon_src }}">
+    {% if brand_settings.primaryFavicon.src %}
+      <link rel="shortcut icon" href="{{ brand_settings.primaryFavicon.src }}" />
     {% endif %}
     <meta name="description" content="{{ page_meta.meta_description }}">
     {{ require_css(get_asset_url('../../css/main.css')) }}


### PR DESCRIPTION
Updating favicon to reference brand_settings instead of site_settings as that will be the new preferred location to pull from.